### PR TITLE
Remove input fields for parcels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Changed
+
+- Remove parcel detail fields when creating a return label
+- Added a default weight setting that return labels will be based on

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -14,6 +14,7 @@ type Mutation {
     country: String
     name: String
     phone: String
+    weight: Float
   ): MutationResponse
   createLabel(
     street1: String
@@ -24,10 +25,6 @@ type Mutation {
     country: String
     name: String
     phone: String
-    height: Float
-    length: Float
-    width: Float
-    weight: Float
   ): Label
 }
 
@@ -43,6 +40,7 @@ type Config {
   country: String
   name: String
   phone: String
+  weight: Float
 }
 
 type Label {
@@ -61,9 +59,6 @@ type Address {
 }
 
 type Parcel {
-  height: Float
-  length: Float
-  width: Float
   weight: Float
 }
 

--- a/messages/context.json
+++ b/messages/context.json
@@ -1,5 +1,18 @@
 {
   "admin-example.navigation.label": "Easypost Integration",
-  "admin-example.hello-world": "",
-  "appframe.navigation.example": ""
+  "admin/navigation.label": "Easypost Integration",
+  "admin/settings.label": "Settings",
+  "admin/settings.address.title": "Default Return Address",
+  "admin/settings.key.label": "Client Key",
+  "admin/settings.name.label": "Name or Company",
+  "admin/settings.street1.label": "Street Address",
+  "admin/settings.street2.label": "Address Line 2",
+  "admin/settings.city.label": "City",
+  "admin/settings.state.label": "State",
+  "admin/settings.zip.label": "Zip Code",
+  "admin/settings.country.label": "Country",
+  "admin/settings.phone.label": "Phone Number",
+  "admin/settings.weight.label": "Default Weight",
+  "admin/settings.weight.help": "Set a default parcel weight for return labels (oz)",
+  "admin/settings.button.label": "Save"
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -1,9 +1,18 @@
 {
+  "admin-example.navigation.label": "Easypost Integration",
   "admin/navigation.label": "Easypost Integration",
-  "admin-example.navigation.label-details": "Example details",
-  "admin-example.navigation.label-table": "Example table",
-  "admin.navigation.search.kws": "test, mock, fake",
-  "admin-example.navigation.details.search.kws": "details, mock, test, hello",
-  "admin.navigation..search.kws": "",
-  "admin-example.hello-world": "Example Admin"
+  "admin/settings.label": "Settings",
+  "admin/settings.address.title": "Default Return Address",
+  "admin/settings.key.label": "Client Key",
+  "admin/settings.name.label": "Name or Company",
+  "admin/settings.street1.label": "Street Address",
+  "admin/settings.street2.label": "Address Line 2",
+  "admin/settings.city.label": "City",
+  "admin/settings.state.label": "State",
+  "admin/settings.zip.label": "Zip Code",
+  "admin/settings.country.label": "Country",
+  "admin/settings.phone.label": "Phone Number",
+  "admin/settings.weight.label": "Default Weight",
+  "admin/settings.weight.help": "Set a default parcel weight for return labels (oz)",
+  "admin/settings.button.label": "Save"
 }

--- a/node/resolvers/index.ts
+++ b/node/resolvers/index.ts
@@ -64,6 +64,7 @@ export const resolvers = {
         country: '',
         name: '',
         phone: '',
+        weight: 0,
       }
 
       if (!settings.title) {
@@ -113,6 +114,7 @@ export const resolvers = {
         country: args.country,
         name: args.name,
         phone: args.phone,
+        weight: args.weight,
       }
 
       try {
@@ -127,20 +129,7 @@ export const resolvers = {
       const apps = new Apps(ctx.vtex)
       const app: string = getAppId()
       const settings: any = await apps.getAppSettings(app)
-      const {
-        street1,
-        street2,
-        city,
-        state,
-        zip,
-        country,
-        name,
-        phone,
-        height,
-        length,
-        width,
-        weight,
-      } = args
+      const { street1, street2, city, state, zip, country, name, phone } = args
 
       const argAddress = {
         street1,
@@ -165,10 +154,7 @@ export const resolvers = {
       }
 
       const argParcel = {
-        height: parseFloat(height),
-        length: parseFloat(length),
-        width: parseFloat(width),
-        weight: parseFloat(weight),
+        weight: parseFloat(settings.weight),
       }
 
       console.log('settings', settings)

--- a/react/EasypostAdmin.tsx
+++ b/react/EasypostAdmin.tsx
@@ -59,6 +59,14 @@ const EasypostAdmin: FC<any> = ({ data: { config }, intl }) => {
       id: 'admin/settings.phone.label',
       defaultMessage: 'Phone Number',
     },
+    weightLabel: {
+      id: 'admin/settings.weight.label',
+      defaultMessage: 'Default Weight',
+    },
+    weightHelp: {
+      id: 'admin/settings.weight.help',
+      defaultMessage: 'Set a default parcel weight for return labels (oz)',
+    },
     saveLabel: {
       id: 'admin/settings.button.label',
       defaultMessage: 'Save',
@@ -75,6 +83,7 @@ const EasypostAdmin: FC<any> = ({ data: { config }, intl }) => {
     country: '',
     name: '',
     phone: '',
+    weight: 10,
   })
 
   const {
@@ -87,6 +96,7 @@ const EasypostAdmin: FC<any> = ({ data: { config }, intl }) => {
     zip,
     country,
     phone,
+    weight,
   } = state
 
   const [saveSettings, { loading: saveLoading }] = useMutation(SAVE_SETTINGS)
@@ -109,6 +119,7 @@ const EasypostAdmin: FC<any> = ({ data: { config }, intl }) => {
       country: config.country,
       name: config.name,
       phone: config.phone,
+      weight: config.weight,
     })
   }
 
@@ -196,6 +207,16 @@ const EasypostAdmin: FC<any> = ({ data: { config }, intl }) => {
             onChange={(e: any) => setState({ ...state, phone: e.target.value })}
           />
         </div>
+        <div className="mt4">
+          <Input
+            label={intl.formatMessage(messages.weightLabel)}
+            value={weight}
+            helpText={intl.formatMessage(messages.weightHelp)}
+            onChange={(e: any) =>
+              setState({ ...state, weight: e.target.value })
+            }
+          />
+        </div>
         <div className="mt6">
           <Button
             isLoading={saveLoading}
@@ -211,6 +232,7 @@ const EasypostAdmin: FC<any> = ({ data: { config }, intl }) => {
                   zip,
                   country,
                   phone,
+                  weight,
                 },
               })
             }}

--- a/react/mutations/createLabel.gql
+++ b/react/mutations/createLabel.gql
@@ -7,9 +7,6 @@ mutation CreateLabel(
   $country: String
   $name: String
   $phone: String
-  $height: Float
-  $length: Float
-  $width: Float
   $weight: Float
 ) {
   createLabel(
@@ -21,9 +18,6 @@ mutation CreateLabel(
     country: $country
     name: $name
     phone: $phone
-    height: $height
-    length: $length
-    width: $width
     weight: $weight
   ) {
     labelUrl

--- a/react/mutations/saveSettings.gql
+++ b/react/mutations/saveSettings.gql
@@ -9,6 +9,7 @@ mutation SaveSettings(
   $country: String
   $name: String
   $phone: String
+  $weight: String
 ) {
   saveSettings(
     title: $title
@@ -21,6 +22,7 @@ mutation SaveSettings(
     country: $country
     name: $name
     phone: $phone
+    weight: $weight
   ) {
     status
     message

--- a/react/queries/config.gql
+++ b/react/queries/config.gql
@@ -10,5 +10,6 @@ query Config {
     country
     name
     phone
+    weight
   }
 }


### PR DESCRIPTION
### Fix
- Remove parcel detail fields when creating a return label
- Returns labels will be generated based off of a `weight` field specified in settings